### PR TITLE
Kubernetes intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # GrayMonk90_platform
 GrayMonk90 Platform repository
+
+## Занятие 2: знакомство с Kubernetes, основные понятия и архитектура
+В ходе выполнения домашней работы была подготовлена репа к GA, на тачку установлены minikube, kubectl, kind и k9s. Дополнительно развернул Kubernetes Dashboard, но по итогу им не пользовался, поскольку k9s стал для меня приятным открытием.  
+
+Изучил восстановление подов из `kube-system` неймспейса.  
+
+Написал Dockerfile с web-server'ом, за основу взял `nginx:1.21.6-alpine`, запушил образ в docker hub и развернул под с этим образом, используя [манифест](kubernetes-intro/web-pod.yaml). После подключения init-контейнера, смог увидеть сгенерированный index.html (лого красивое :thumbsup:).  
+
+Собрал фронт microservices-demo, развернул с помощью `kubectl run ...`, сохранил манифест (`-o yaml > frontend-pod.yaml`). Исправил ошибку при запуске пода, исправления внес в [манифест](kubernetes-intro/frontend-pod-healthy.yaml).

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: serg2/hipster-frontend:v0.0.1
+    name: frontend
+    resources: {}
+    env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: webservice
+  labels: 
+    application: nginx
+spec:
+  containers:
+  - name: webservice
+    image: serg2/webservice-demo:1.0
+    volumeMounts:
+      - name: app
+        mountPath: /app
+  initContainers:
+  - name: init-webservice
+    image: busybox:1.28
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+    volumeMounts:
+      - name: app
+        mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,17 @@
+FROM nginx:1.21.6-alpine
+
+WORKDIR /app
+
+RUN addgroup -g 1001 -S app_user && \
+    adduser -u 1001 -S app_user -G app_user && \
+    touch /var/run/nginx.pid && \
+    chown -R app_user: /var/cache/nginx /var/log/nginx /var/run/nginx.pid /app
+
+RUN sed -i 's/user  nginx/user app_user/' /etc/nginx/nginx.conf
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+USER app_user
+
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/web/default.conf
+++ b/kubernetes-intro/web/default.conf
@@ -1,0 +1,6 @@
+server {
+    listen       8000;
+    location / {
+        root   /app;
+    }
+}


### PR DESCRIPTION
# Выполнено ДЗ №2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Подготовлено локальное окружение (minikube, kubectl, kind, k9s);
 - Изучена причина восстановления pod'ов после их удаления;
 - Создан web-сервис, использующий init-контейнер;
 - Развернут и отдебажен фронт microservices-demo.

## Как запустить проект:
 - **Web-сервис c init'ом**. Находясь в корне проекта выполнить: `kubectl apply -f kubernetes-intro/web-pod.yaml`;
 - **Frontend приложения microservices-demo**. Находясь в корне проекта выполнить: `kubectl apply -f kubernetes-intro/frontend-pod-healthy.yaml`.

## Как проверить работоспособность:
 - **Web-сервис c init'ом**. Выполнить команду `kubectl port-forward --address 0.0.0.0 pod/webservice 8000:8000` и отркрыть в браузере `http://localhost:8000/index.html`, на странице должна находится системная информация;
 - **Frontend приложения microservices-demo**. Pod `frontend` должен находится в статусе `Running`.
 
## Развернутый ответ: 
> Разберитесь почему все pod в namespace kube-system восстановились после удаления

CoreDNS управляется с помощью контроллера Deployments, kube-proxy - с помощью DaemonSet. Etcd, kube-apiserver, kube-controller-manager и kube-scheduler, являясь статическими подами (static pods), управляются демоном kubelet. По умолчанию манифесты хранятся в /etc/kubernetes/manifests.

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
